### PR TITLE
replace NAudio with SoundFlow

### DIFF
--- a/OofPlugin/Configuration.cs
+++ b/OofPlugin/Configuration.cs
@@ -26,6 +26,7 @@ namespace OofPlugin {
     //audio settings
     public float Volume { get; set; } = 0.5f;
     public string DefaultSoundImportPath { get; set; } = string.Empty;
+    public bool AudioOverlap { get; set; } = false;
 
     // the below exist just to make saving less cumbersome
 

--- a/OofPlugin/OofPlugin.csproj
+++ b/OofPlugin/OofPlugin.csproj
@@ -23,7 +23,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="DalamudPackager" Version="15.0.0" />
 		<PackageReference Include="SoundFlow" Version="1.4.0" />		
 	</ItemGroup>
 	<ItemGroup>

--- a/OofPlugin/OofPlugin.csproj
+++ b/OofPlugin/OofPlugin.csproj
@@ -23,8 +23,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NAudio.Core" Version="2.2.1" />
-		<PackageReference Include="NAudio.Wasapi" Version="2.2.1" />		
+		<PackageReference Update="DalamudPackager" Version="15.0.0" />
+		<PackageReference Include="SoundFlow" Version="1.4.0" />		
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="OofPlugin.yaml">

--- a/OofPlugin/SoundManager.cs
+++ b/OofPlugin/SoundManager.cs
@@ -1,9 +1,15 @@
-using NAudio.Wave;
+using SoundFlow.Abstracts.Devices;
+using SoundFlow.Backends.MiniAudio;
+using SoundFlow.Components;
+using SoundFlow.Providers;
 using System;
 using System.IO;
+using System.Linq;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
+using AudioFormat = SoundFlow.Structs.AudioFormat;
+using PlaybackState = SoundFlow.Enums.PlaybackState;
 
 namespace OofPlugin;
 
@@ -12,9 +18,13 @@ internal class SoundManager : IDisposable {
   private readonly DeadPlayersList DeadPlayersList;
 
   // sound
-  public bool isSoundPlaying { get; private set; } = false;
-  private DirectSoundOut? soundOut;
-  private string? soundFile;
+  private string soundFile;
+
+  private MiniAudioEngine engine;
+  private AudioPlaybackDevice playbackDevice;
+  private AudioFormat audioFormat;
+  private StreamDataProvider dataProvider;
+  private SoundPlayer player;
 
   internal CancellationTokenSource CancelToken;
 
@@ -22,17 +32,30 @@ internal class SoundManager : IDisposable {
     Configuration = plugin.Configuration;
     DeadPlayersList = plugin.DeadPlayersList;
 
-    LoadFile();
+    engine = new MiniAudioEngine();
+    engine.UpdateAudioDevicesInfo();
 
+    // Get the system default playback device 
+    var defaultDevice = engine.PlaybackDevices.FirstOrDefault(x => x.IsDefault);
+    audioFormat = AudioFormat.DvdHq;
+    playbackDevice = engine.InitializePlaybackDevice(defaultDevice, audioFormat);
+
+    LoadFile();
+    dataProvider = new StreamDataProvider(engine, audioFormat, File.OpenRead(soundFile));
+    player = new SoundPlayer(engine, audioFormat, dataProvider);
+
+    player.PlaybackEnded += (_, _) => player.Stop();
+
+    playbackDevice.MasterMixer.AddComponent(player);
+    playbackDevice.Start();
+    
     CancelToken = new CancellationTokenSource();
     Task.Run(() => OofAudioPolling(CancelToken.Token));
   }
 
   public void LoadFile() {
     if (string.IsNullOrEmpty(Configuration.DefaultSoundImportPath)) {
-      soundFile = Path.Combine(
-          Dalamud.PluginInterface.AssemblyLocation.Directory!.FullName,
-          "oof.wav");
+      soundFile = Path.Combine(Dalamud.PluginInterface.AssemblyLocation.Directory!.FullName, "oof.wav");
       return;
     }
 
@@ -40,54 +63,19 @@ internal class SoundManager : IDisposable {
   }
 
   public void Stop() {
-    soundOut?.Pause();
-    soundOut?.Dispose();
-    soundOut = null;
+    player.Stop();
   }
 
   public void Play(CancellationToken token, float volume = 1f) {
     _ = Task.Run(() => {
-      isSoundPlaying = true;
-
-      WaveStream reader;
-      try {
-        reader = new MediaFoundationReader(soundFile);
-      }
-      catch (Exception ex) {
-        isSoundPlaying = false;
-        Dalamud.Log.Error("Failed to read sound file", ex);
-        return;
+      // To play a sound, we need to stop it first if it's already playing
+      if (player.State == PlaybackState.Playing) {
+        player.Stop();
       }
 
-      var audioStream =
-          new WaveChannel32(reader) {
-            Volume = Configuration.Volume * volume,
-            PadWithZeroes = false // you need this or else playbackstopped event will not fire
-          };
-
-      using (reader) {
-        soundOut?.Pause();
-        soundOut?.Dispose();
-        soundOut = new DirectSoundOut();
-
-        try {
-          soundOut.Init(audioStream);
-          soundOut.Play();
-
-          soundOut.PlaybackStopped += (_, _) => { isSoundPlaying = false; };
-        }
-        catch (Exception ex) {
-          isSoundPlaying = false;
-          Dalamud.Log.Error("Failed to play sound", ex);
-        }
-      }
-    }, token).ContinueWith((t) => {
-      t.Exception?.Handle((e) => {
-        Dalamud.Log.Error($"Failed to dispose DirectSoundOut {e} ");
-
-        return true;
-      });
-    });
+      player.Volume = volume;
+      player.Play();
+    }, token);
   }
 
   private async Task OofAudioPolling(CancellationToken token) {
@@ -100,8 +88,7 @@ internal class SoundManager : IDisposable {
 
         // Run on framework thread AND await it so exceptions are observed
         await Dalamud.Framework.RunOnFrameworkThread(() => {
-          var localPlayer =
-              Dalamud.ObjectTable.LocalPlayer;
+          var localPlayer = Dalamud.ObjectTable.LocalPlayer;
           if (localPlayer is null)
             return;
 
@@ -111,10 +98,8 @@ internal class SoundManager : IDisposable {
 
             float volume = 1f;
 
-            if (Configuration.DistanceBasedOof &&
-                player.Distance != Vector3.Zero) {
-              var dist =
-                  Vector3.Distance(localPlayer.Position, player.Distance);
+            if (Configuration.DistanceBasedOof && player.Distance != Vector3.Zero) {
+              var dist = Vector3.Distance(localPlayer.Position, player.Distance);
               volume = VolumeFromDist(dist);
             }
 
@@ -139,8 +124,8 @@ internal class SoundManager : IDisposable {
     dist = Math.Min(dist, distMax);
 
     var falloff = Configuration.DistanceFalloff > 0
-                      ? 3f - Configuration.DistanceFalloff * 3f
-                      : 2.999f;
+      ? 3f - Configuration.DistanceFalloff * 3f
+      : 2.999f;
 
     var vol = 1f - ((dist / distMax) * (1f / falloff));
     return Math.Max(Configuration.DistanceMinVolume, vol);
@@ -164,8 +149,11 @@ internal class SoundManager : IDisposable {
   public void Dispose() {
     CancelToken.Cancel();
     CancelToken.Dispose();
-
-    soundOut?.Dispose();
-    soundOut = null;
+    
+    playbackDevice.MasterMixer.RemoveComponent(player);
+    player.Dispose();
+    dataProvider.Dispose();
+    playbackDevice.Dispose();
+    engine.Dispose();
   }
 }

--- a/OofPlugin/SoundManager.cs
+++ b/OofPlugin/SoundManager.cs
@@ -10,7 +10,6 @@ using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using AudioFormat = SoundFlow.Structs.AudioFormat;
-using PlaybackState = SoundFlow.Enums.PlaybackState;
 
 namespace OofPlugin;
 
@@ -19,12 +18,12 @@ internal class SoundManager : IDisposable {
   private readonly DeadPlayersList DeadPlayersList;
 
   // sound
-  private string soundFile;
+  private string? soundFile;
 
-  private MiniAudioEngine engine;
-  private AudioPlaybackDevice playbackDevice;
+  private readonly MiniAudioEngine engine;
+  private AudioPlaybackDevice? playbackDevice;
   private AudioFormat audioFormat;
-  private List<SoundPlayer> activePlayers = new();
+  private readonly List<SoundPlayer> activePlayers = new();
 
 
   internal CancellationTokenSource CancelToken;
@@ -33,19 +32,10 @@ internal class SoundManager : IDisposable {
     Configuration = plugin.Configuration;
     DeadPlayersList = plugin.DeadPlayersList;
 
-    engine = new MiniAudioEngine();
-    engine.UpdateAudioDevicesInfo();
-
-    // Get the system default playback device 
-    var defaultDevice = engine.PlaybackDevices.FirstOrDefault(x => x.IsDefault);
-    
-    audioFormat = AudioFormat.DvdHq;
-    playbackDevice = engine.InitializePlaybackDevice(defaultDevice, audioFormat);
-
     LoadFile();
     
-    playbackDevice.Start();
-    
+    engine = new MiniAudioEngine();
+    InitializeAudioDevice();
     
     CancelToken = new CancellationTokenSource();
     Task.Run(() => OofAudioPolling(CancelToken.Token));
@@ -61,13 +51,47 @@ internal class SoundManager : IDisposable {
   }
 
   /// <summary>
+  /// Create the playback device using the current system default output and starts it, if it's already
+  /// created it will be destroyed and re-created, safely
+  /// Falls back to logging an error if device discovery or initialization fails.
+  /// </summary>
+  public void InitializeAudioDevice() {
+    DestroyAudioDevice();
+
+    try {
+      engine.UpdateAudioDevicesInfo();
+
+      // Get the system default playback device 
+      var defaultDevice = engine.PlaybackDevices.FirstOrDefault(x => x.IsDefault);
+
+      audioFormat = AudioFormat.DvdHq;
+      playbackDevice = engine.InitializePlaybackDevice(defaultDevice, audioFormat);
+      playbackDevice.Start();
+    }
+    catch (Exception ex) {
+      Dalamud.Log.Error(ex, "OOF: OofAudioRecreateAudioDevice failed");
+    }
+  }
+
+
+  private void DestroyAudioDevice() {
+    Stop();
+    
+    if(playbackDevice != null) {
+      playbackDevice.Stop();
+      playbackDevice.Dispose();
+    }
+    
+  }
+
+  /// <summary>
   /// Stops all active sound players and cleans up their resources.
   /// </summary>
   public void Stop() {
     lock (activePlayers) {
       activePlayers.ForEach(x => {
         x.Stop();
-        playbackDevice.MasterMixer.RemoveComponent(x);
+        playbackDevice?.MasterMixer.RemoveComponent(x);
         x.Dispose();
       });
 
@@ -80,22 +104,26 @@ internal class SoundManager : IDisposable {
       if (!Configuration.AudioOverlap) {
         Stop(); 
       }
+
+      if (soundFile == null) {
+        Dalamud.Log.Error("OOF: No sound file found to play.");
+        return;
+      }
       
       var dataProvider = new StreamDataProvider(engine, audioFormat, File.OpenRead(soundFile));
       var player = new SoundPlayer(engine, audioFormat, dataProvider);
       
       lock(activePlayers) { activePlayers.Add(player); }
       
-      playbackDevice.MasterMixer.AddComponent(player);
+      playbackDevice?.MasterMixer.AddComponent(player);
       
       // this cleans up after the playback ends
       player.PlaybackEnded += (_, _) => {
-        lock(activePlayers) { activePlayers.Remove(player); };
+        lock(activePlayers) { activePlayers.Remove(player); }
         player.Stop();
-        playbackDevice.MasterMixer.RemoveComponent(player);
+        playbackDevice?.MasterMixer.RemoveComponent(player);
         player.Dispose();
       };
-      
       
       player.Volume = volume;
       player.Play();
@@ -174,7 +202,7 @@ internal class SoundManager : IDisposable {
     CancelToken.Cancel();
     CancelToken.Dispose();
     
-    playbackDevice.Dispose();
+    playbackDevice?.Dispose();
     engine.Dispose();
   }
 }

--- a/OofPlugin/SoundManager.cs
+++ b/OofPlugin/SoundManager.cs
@@ -41,13 +41,6 @@ internal class SoundManager : IDisposable {
     playbackDevice = engine.InitializePlaybackDevice(defaultDevice, audioFormat);
 
     LoadFile();
-    dataProvider = new StreamDataProvider(engine, audioFormat, File.OpenRead(soundFile));
-    player = new SoundPlayer(engine, audioFormat, dataProvider);
-
-    player.PlaybackEnded += (_, _) => player.Stop();
-
-    playbackDevice.MasterMixer.AddComponent(player);
-    playbackDevice.Start();
     
     CancelToken = new CancellationTokenSource();
     Task.Run(() => OofAudioPolling(CancelToken.Token));
@@ -68,6 +61,18 @@ internal class SoundManager : IDisposable {
 
   public void Play(CancellationToken token, float volume = 1f) {
     _ = Task.Run(() => {
+      dataProvider = new StreamDataProvider(engine, audioFormat, File.OpenRead(soundFile));
+      player = new SoundPlayer(engine, audioFormat, dataProvider);
+      playbackDevice.MasterMixer.AddComponent(player);
+      playbackDevice.Start();
+      
+      player.PlaybackEnded += (_, _) => {
+        player.Stop();
+        playbackDevice.MasterMixer.RemoveComponent(player);
+        player.Dispose();
+      };
+
+      
       // To play a sound, we need to stop it first if it's already playing
       if (player.State == PlaybackState.Playing) {
         player.Stop();

--- a/OofPlugin/SoundManager.cs
+++ b/OofPlugin/SoundManager.cs
@@ -3,6 +3,7 @@ using SoundFlow.Backends.MiniAudio;
 using SoundFlow.Components;
 using SoundFlow.Providers;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -23,7 +24,7 @@ internal class SoundManager : IDisposable {
   private MiniAudioEngine engine;
   private AudioPlaybackDevice playbackDevice;
   private AudioFormat audioFormat;
-  private SoundPlayer? currentPlayer;
+  private List<SoundPlayer> activePlayers = new();
 
 
   internal CancellationTokenSource CancelToken;
@@ -43,6 +44,9 @@ internal class SoundManager : IDisposable {
 
     LoadFile();
     
+    playbackDevice.Start();
+    
+    
     CancelToken = new CancellationTokenSource();
     Task.Run(() => OofAudioPolling(CancelToken.Token));
   }
@@ -56,31 +60,37 @@ internal class SoundManager : IDisposable {
     soundFile = Configuration.DefaultSoundImportPath;
   }
 
+  /// <summary>
+  /// Stops all active sound players and cleans up their resources.
+  /// </summary>
   public void Stop() {
-    // When an audio plays this will cause a tiny lag spike, but as this is only used in the ConfigWindow, it
-    // should be fine
-    playbackDevice.Stop();
+    lock (activePlayers) {
+      activePlayers.ForEach(x => {
+        x.Stop();
+        playbackDevice.MasterMixer.RemoveComponent(x);
+        x.Dispose();
+      });
+
+      activePlayers.Clear();
+    }
   }
 
   public void Play(CancellationToken token, float volume = 1f) {
     _ = Task.Run(() => {
-      if (!Configuration.AudioOverlap && currentPlayer != null) {
-        currentPlayer.Stop();
-        playbackDevice.MasterMixer.RemoveComponent(currentPlayer); 
-        currentPlayer.Dispose();
-        currentPlayer = null;
+      if (!Configuration.AudioOverlap) {
+        Stop(); 
       }
       
       var dataProvider = new StreamDataProvider(engine, audioFormat, File.OpenRead(soundFile));
       var player = new SoundPlayer(engine, audioFormat, dataProvider);
       
-      currentPlayer = player;
+      lock(activePlayers) { activePlayers.Add(player); }
       
       playbackDevice.MasterMixer.AddComponent(player);
-      playbackDevice.Start();
       
       // this cleans up after the playback ends
       player.PlaybackEnded += (_, _) => {
+        lock(activePlayers) { activePlayers.Remove(player); };
         player.Stop();
         playbackDevice.MasterMixer.RemoveComponent(player);
         player.Dispose();

--- a/OofPlugin/SoundManager.cs
+++ b/OofPlugin/SoundManager.cs
@@ -23,6 +23,7 @@ internal class SoundManager : IDisposable {
   private MiniAudioEngine engine;
   private AudioPlaybackDevice playbackDevice;
   private AudioFormat audioFormat;
+  private SoundPlayer? currentPlayer;
 
 
   internal CancellationTokenSource CancelToken;
@@ -36,6 +37,7 @@ internal class SoundManager : IDisposable {
 
     // Get the system default playback device 
     var defaultDevice = engine.PlaybackDevices.FirstOrDefault(x => x.IsDefault);
+    
     audioFormat = AudioFormat.DvdHq;
     playbackDevice = engine.InitializePlaybackDevice(defaultDevice, audioFormat);
 
@@ -62,8 +64,18 @@ internal class SoundManager : IDisposable {
 
   public void Play(CancellationToken token, float volume = 1f) {
     _ = Task.Run(() => {
+      if (!Configuration.AudioOverlap && currentPlayer != null) {
+        currentPlayer.Stop();
+        playbackDevice.MasterMixer.RemoveComponent(currentPlayer); 
+        currentPlayer.Dispose();
+        currentPlayer = null;
+      }
+      
       var dataProvider = new StreamDataProvider(engine, audioFormat, File.OpenRead(soundFile));
       var player = new SoundPlayer(engine, audioFormat, dataProvider);
+      
+      currentPlayer = player;
+      
       playbackDevice.MasterMixer.AddComponent(player);
       playbackDevice.Start();
       
@@ -74,9 +86,6 @@ internal class SoundManager : IDisposable {
         player.Dispose();
       };
       
-      if (player.State == PlaybackState.Playing) {
-        player.Stop();
-      }
       
       player.Volume = volume;
       player.Play();

--- a/OofPlugin/SoundManager.cs
+++ b/OofPlugin/SoundManager.cs
@@ -25,7 +25,8 @@ internal class SoundManager : IDisposable {
   private AudioFormat audioFormat;
   private readonly List<SoundPlayer> activePlayers = new();
 
-
+  private bool isInitialized = false;
+  
   internal CancellationTokenSource CancelToken;
 
   public SoundManager(OofPlugin plugin) {
@@ -67,8 +68,11 @@ internal class SoundManager : IDisposable {
       audioFormat = AudioFormat.DvdHq;
       playbackDevice = engine.InitializePlaybackDevice(defaultDevice, audioFormat);
       playbackDevice.Start();
+
+      isInitialized = true;
     }
     catch (Exception ex) {
+      isInitialized = false;
       Dalamud.Log.Error(ex, "OOF: OofAudioRecreateAudioDevice failed");
     }
   }
@@ -88,6 +92,8 @@ internal class SoundManager : IDisposable {
   /// Stops all active sound players and cleans up their resources.
   /// </summary>
   public void Stop() {
+    if (!isInitialized) return;
+    
     lock (activePlayers) {
       activePlayers.ForEach(x => {
         x.Stop();
@@ -100,6 +106,8 @@ internal class SoundManager : IDisposable {
   }
 
   public void Play(CancellationToken token, float volume = 1f) {
+    if (!isInitialized) return;
+    
     _ = Task.Run(() => {
       if (!Configuration.AudioOverlap) {
         Stop(); 

--- a/OofPlugin/SoundManager.cs
+++ b/OofPlugin/SoundManager.cs
@@ -23,8 +23,7 @@ internal class SoundManager : IDisposable {
   private MiniAudioEngine engine;
   private AudioPlaybackDevice playbackDevice;
   private AudioFormat audioFormat;
-  private StreamDataProvider dataProvider;
-  private SoundPlayer player;
+
 
   internal CancellationTokenSource CancelToken;
 
@@ -56,28 +55,29 @@ internal class SoundManager : IDisposable {
   }
 
   public void Stop() {
-    player.Stop();
+    // When an audio plays this will cause a tiny lag spike, but as this is only used in the ConfigWindow, it
+    // should be fine
+    playbackDevice.Stop();
   }
 
   public void Play(CancellationToken token, float volume = 1f) {
     _ = Task.Run(() => {
-      dataProvider = new StreamDataProvider(engine, audioFormat, File.OpenRead(soundFile));
-      player = new SoundPlayer(engine, audioFormat, dataProvider);
+      var dataProvider = new StreamDataProvider(engine, audioFormat, File.OpenRead(soundFile));
+      var player = new SoundPlayer(engine, audioFormat, dataProvider);
       playbackDevice.MasterMixer.AddComponent(player);
       playbackDevice.Start();
       
+      // this cleans up after the playback ends
       player.PlaybackEnded += (_, _) => {
         player.Stop();
         playbackDevice.MasterMixer.RemoveComponent(player);
         player.Dispose();
       };
-
       
-      // To play a sound, we need to stop it first if it's already playing
       if (player.State == PlaybackState.Playing) {
         player.Stop();
       }
-
+      
       player.Volume = volume;
       player.Play();
     }, token);
@@ -155,9 +155,6 @@ internal class SoundManager : IDisposable {
     CancelToken.Cancel();
     CancelToken.Dispose();
     
-    playbackDevice.MasterMixer.RemoveComponent(player);
-    player.Dispose();
-    dataProvider.Dispose();
     playbackDevice.Dispose();
     engine.Dispose();
   }

--- a/OofPlugin/Windows/ConfigWindow.cs
+++ b/OofPlugin/Windows/ConfigWindow.cs
@@ -66,6 +66,13 @@ public class ConfigWindow : Window, IDisposable {
       Configuration.Save();
     };
     ImGuiComponents.HelpMarker("Overlap audio instead of stopping an already playing audio");
+
+    ImGui.Spacing();
+    if (ImGui.Button("Reload Audio Devices")) {
+      Plugin.SoundManager.InitializeAudioDevice(); 
+    }
+    
+    
     ImGui.Spacing();
     ImGui.TextColoredWrapped(headingColor, "Play sound on");
 
@@ -329,7 +336,5 @@ public class ConfigWindow : Window, IDisposable {
 
     return fileManager;
   }
-
-
 }
 

--- a/OofPlugin/Windows/ConfigWindow.cs
+++ b/OofPlugin/Windows/ConfigWindow.cs
@@ -59,6 +59,14 @@ public class ConfigWindow : Window, IDisposable {
 
     ImGui.Spacing();
 
+    ImGui.TextColoredWrapped(headingColor, "Settings");
+    var audioOverlap = Configuration.AudioOverlap;
+    if (ImGui.Checkbox("Allow audio overlap###config:overlap", ref audioOverlap)) {
+      Configuration.AudioOverlap = audioOverlap;
+      Configuration.Save();
+    };
+    ImGuiComponents.HelpMarker("Overlap audio instead of stopping an already playing audio");
+    ImGui.Spacing();
     ImGui.TextColoredWrapped(headingColor, "Play sound on");
 
     // when self falls options

--- a/OofPlugin/packages.lock.json
+++ b/OofPlugin/packages.lock.json
@@ -14,20 +14,11 @@
         "resolved": "1.2.39",
         "contentHash": "fcFN01tDTIQqDuTwr1jUQK/geofiwjG5DycJQOnC72i1SsLAk1ELe+apBOuZ11UMQG8YKFZG1FgvjZPbqHyatg=="
       },
-      "NAudio.Core": {
+      "SoundFlow": {
         "type": "Direct",
-        "requested": "[2.2.1, )",
-        "resolved": "2.2.1",
-        "contentHash": "GgkdP6K/7FqXFo7uHvoqGZTJvW4z8g2IffhOO4JHaLzKCdDOUEzVKtveoZkCuUX8eV2HAINqi7VFqlFndrnz/g=="
-      },
-      "NAudio.Wasapi": {
-        "type": "Direct",
-        "requested": "[2.2.1, )",
-        "resolved": "2.2.1",
-        "contentHash": "lFfXoqacZZe0WqNChJgGYI+XV/n/61LzPHT3C1CJp4khoxeo2sziyX5wzNYWeCMNbsWxFvT3b3iXeY1UYjBhZw==",
-        "dependencies": {
-          "NAudio.Core": "2.2.1"
-        }
+        "requested": "[1.4.0, )",
+        "resolved": "1.4.0",
+        "contentHash": "PVc8NEpwmx16qJdOGRvc7Kpvs/3hNZBuldErmnMQSh9IClAA2UWrafcUIQUxki2GrWB2g71hPSDIUKEo3nRgeA=="
       }
     }
   }


### PR DESCRIPTION
This is what i have when i replaced NAudio with SoundFlow, i'm not sure how we and if should handle:
- Cases where no audio devices can be found (or would it be safe for us to assume there would always be 1)
- Cases where the audio device are changed while the plugin is running (e.g from speakers to headset, vice versa)

I've being testing this during my merc runs yesterday, with no crashes and audio played as i would expect, as i'm unable to test NAudio, i can't tell if it works exactly the same (feedback would be required)

Fixes: #13 